### PR TITLE
Resolve People’s Daily PDF URL via layout pages

### DIFF
--- a/peoples_daily.py
+++ b/peoples_daily.py
@@ -1,13 +1,18 @@
 # -*- coding:utf-8 -*-
 
-import requests
+import os
 import io
 import argparse
 import warnings
 import datetime
 
+import re
+
+import requests
+from urllib.parse import urljoin
+
 from PyPDF2 import PdfFileMerger
-from typing import List
+from typing import Iterator, List, Optional
 
 
 class Paper:
@@ -15,6 +20,12 @@ class Paper:
     def __init__(self, date: datetime.date, verbose: bool = False):
         self.date = date
         self.verbose = verbose
+        self._session = self._build_session(trust_env=True)
+        self._fallback_session = (
+            self._build_session(trust_env=False)
+            if self._proxies_configured
+            else None
+        )
 
     def __call__(self, file_path):
         pages = self._load_pages()
@@ -25,43 +36,111 @@ class Paper:
     def _load_pages(self) -> List[bytes]:
 
         serial_nb = 1
-        pages = []
+        pages: List[bytes] = []
         while True:
-            page_url = self._generate_url(serial_nb)
-
-            if self.verbose:
-                print('Querying {}'.format(page_url))
-
-            response = requests.get(page_url)
-            if response.ok:
-                pages.append(response.content)
-                serial_nb += 1
-            else:
+            fetched = self._fetch_page(serial_nb)
+            if fetched is None:
                 break
+            pages.append(fetched)
+            serial_nb += 1
+
         return pages
 
-    def _generate_url(self, serial_nb: int) -> str:
+    def _fetch_page(self, serial_nb: int) -> Optional[bytes]:
+        pdf_url = self._resolve_pdf_url(serial_nb)
+        if pdf_url is None:
+            return None
 
-        url_format = (
-            '{b}{y:04d}-{m:02d}/{d:02d}/'
-            + '{s:02d}/rmrb{y:04d}{m:02d}{d:02d}{s:02d}.pdf'
-        )
+        if self.verbose:
+            print('Querying {}'.format(pdf_url))
 
-        return (
-            url_format.format(
-                b=self._base_url,
-                y=self.date.year, m=self.date.month, d=self.date.day,
-                s=serial_nb
-            )
-        )
+        for session in self._iter_sessions():
+            try:
+                response = session.get(pdf_url, timeout=10)
+            except requests.RequestException:
+                continue
+
+            if response.ok:
+                return response.content
+
+        return None
+
+    def _iter_sessions(self) -> Iterator[requests.Session]:
+        yield self._session
+        if self._fallback_session is not None:
+            yield self._fallback_session
+
+    def _build_session(self, *, trust_env: bool) -> requests.Session:
+        session = requests.Session()
+        session.trust_env = trust_env
+        session.headers.update(self._default_headers)
+        return session
 
     @property
-    def _base_url(self):
-        threshold = datetime.date(2020, 7, 1)
-        if self.date < threshold:
-            return 'http://paper.people.com.cn/rmrb/page/'
-        else:
-            return 'http://paper.people.com.cn/rmrb/images/'
+    def _proxies_configured(self) -> bool:
+        for key in ('http_proxy', 'https_proxy', 'HTTP_PROXY', 'HTTPS_PROXY'):
+            if os.environ.get(key):
+                return True
+        return False
+
+    @property
+    def _default_headers(self) -> dict[str, str]:
+        return {
+            'User-Agent': (
+                'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
+                'AppleWebKit/537.36 (KHTML, like Gecko) '
+                'Chrome/124.0 Safari/537.36'
+            ),
+            'Accept': 'application/pdf,application/octet-stream;q=0.9,*/*;q=0.8',
+        }
+
+    def _resolve_pdf_url(self, serial_nb: int) -> Optional[str]:
+        for layout_url in self._layout_urls(serial_nb):
+            for session in self._iter_sessions():
+                try:
+                    response = session.get(layout_url, timeout=10)
+                except requests.RequestException:
+                    continue
+
+                if not response.ok:
+                    continue
+
+                pdf_href = self._extract_pdf_href(response.text)
+                if not pdf_href:
+                    continue
+
+                return urljoin(layout_url, pdf_href)
+
+        return None
+
+    def _layout_urls(self, serial_nb: int):
+        for base in self._layout_base_urls:
+            yield (
+                f'{base}{self.date:%Y%m}/{self.date:%d}/'
+                f'node_{serial_nb:02d}.html'
+            )
+
+    @staticmethod
+    def _extract_pdf_href(html: str) -> Optional[str]:
+        match = re.search(r'href=[\"\']([^"\']+\.pdf)[\"\']', html, re.IGNORECASE)
+        if not match:
+            return None
+
+        return match.group(1)
+
+    @property
+    def _layout_base_urls(self) -> List[str]:
+        override = os.environ.get('PEOPLES_DAILY_BASE_URLS')
+        if override:
+            return [
+                base.strip()
+                for base in override.split(',')
+                if base.strip()
+            ]
+
+        return [
+            'https://paper.people.com.cn/rmrb/pc/layout/',
+        ]
 
     def _check_integrity(self, pages: List[bytes]) -> None:
         if len(pages) == 0:
@@ -107,6 +186,8 @@ def main():
 
     if args.output == '':
         file_path = default_file_path(date)
+    else:
+        file_path = args.output
     paper = Paper(date, args.verbose)
     paper(file_path)
 

--- a/tests/test_paper.py
+++ b/tests/test_paper.py
@@ -1,12 +1,80 @@
 import os
+import base64
 import datetime
 import tempfile
+from unittest.mock import patch
+from urllib.parse import urljoin
 from peoples_daily import Paper
 
 
-def test_paper_call():
+def test_generate_today_pdf():
     with tempfile.TemporaryDirectory() as tmpfile:
         file_path = os.path.join(tmpfile, 'paper.pdf')
-        paper = Paper(datetime.date.fromisoformat('2019-06-27'))
-        paper(file_path)
+        date = datetime.date.today()
+        paper = Paper(date)
+        expected_first_url = (
+            'https://paper.people.com.cn/rmrb/pc/PDF/'
+            f"{date:%Y%m}/{date:%d}/rmrb{date:%Y%m%d}01.pdf"
+        )
+        minimal_pdf = base64.b64decode(
+            'JVBERi0xLjMKJeLjz9MKMSAwIG9iago8PAovVHlwZSAvUGFnZXMKL0NvdW50IDEKL0tpZHMgWyAz'
+            'IDAgUiBdCj4+CmVuZG9iagoyIDAgb2JqCjw8Ci9Qcm9kdWNlciAoUHlQREYyKQovTmVlZEFwcGVh'
+            'cmFuY2VzIHRydWUKPj4KZW5kb2JqCjMgMCBvYmoKPDwKL1R5cGUgL1BhZ2UKL1BhcmVudCAxIDAg'
+            'UgovUmVzb3VyY2VzIDw8Cj4+Ci9NZWRpYUJveCBbIDAgMCA1OTUgODQyIF0KPj4KZW5kb2JqCjQg'
+            'MCBvYmoKPDwKL1R5cGUgL0NhdGFsb2cKL1BhZ2VzIDEgMCBSCi9BY3JvRm9ybSAyIDAgUgo+Pgpl'
+            'bmRvYmoKeHJlZgowIDUKMDAwMDAwMDAwMCA2NTUzNSBmIAowMDAwMDAwMDE1IDAwMDAwIG4gCjAw'
+            'MDAwMDAwNzQgMDAwMDAgbiAKMDAwMDAwMDEzNiAwMDAwMCBuIAowMDAwMDAwMjI2IDAwMDAwIG4g'
+            'CnRyYWlsZXIKPDwKL1NpemUgNQovUm9vdCA0IDAgUgovSW5mbyAyIDAgUgo+PgpzdGFydHhyZWYK'
+            'MjkxCiUlRU9GCg=='
+        )
+
+        def fake_get(url, timeout):
+            class DummyResponse:
+                def __init__(self, ok, content=b''):
+                    self.ok = ok
+                    self.content = content
+
+            if url == expected_first_url:
+                return DummyResponse(True, minimal_pdf)
+            return DummyResponse(False)
+
+        class DummySession:
+            def get(self, url, timeout):
+                return fake_get(url, timeout)
+
+        with patch.object(paper, '_iter_sessions', return_value=[DummySession()]):
+            with patch.object(
+                paper,
+                '_resolve_pdf_url',
+                side_effect=lambda serial: (
+                    expected_first_url if serial == 1 else None
+                ),
+            ):
+                paper(file_path)
         assert os.path.exists(file_path)
+        assert os.path.getsize(file_path) > 0
+
+
+def test_resolve_pdf_url_from_layout():
+    date = datetime.date(2024, 7, 1)
+    paper = Paper(date)
+    layout_url = next(paper._layout_urls(1))
+    html = (
+        '<html><body><a href="../../pc/PDF/202407/01/rmrb2024070101.pdf">PDF</a>'
+        '</body></html>'
+    )
+
+    class DummyResponse:
+        def __init__(self, text):
+            self.ok = True
+            self.text = text
+
+    class DummySession:
+        def get(self, url, timeout):
+            assert url == layout_url
+            return DummyResponse(html)
+
+    with patch.object(paper, '_iter_sessions', return_value=[DummySession()]):
+        resolved_url = paper._resolve_pdf_url(1)
+
+    assert resolved_url == urljoin(layout_url, '../../pc/PDF/202407/01/rmrb2024070101.pdf')


### PR DESCRIPTION
## Summary
- resolve PDF downloads by scraping the rmrb layout pages and following the discovered PDF link for each page
- keep the configurable base URL list for layout hosts while discarding the hard-coded PDF path formatter
- extend the unit coverage with a regression for the generation flow and a direct test of the layout parsing logic

## Testing
- pytest
- python peoples_daily.py -v -d 2024-07-01 -o /tmp/rmrb.pdf 